### PR TITLE
fix manyagent-swimmer/ant and coupled-half-cheetah; fix examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ env_args.agent_obsk=1
 
 ```python
 env_args.scenario="Walker2d-v2"
-env_args.agent_conf="2x3
+env_args.agent_conf="2x3"
 env_args.agent_obsk=1
 ```
 
@@ -189,7 +189,7 @@ env_args.agent_obsk=1
 
 ```python
 env_args.scenario="manyagent_swimmer"
-env_args.agent_conf="2x3
+env_args.agent_conf="10x2"
 env_args.agent_obsk=1
 ```
 
@@ -198,7 +198,7 @@ env_args.agent_obsk=1
 
 ```python
 env_args.scenario="manyagent_ant"
-env_args.agent_conf="2x3
+env_args.agent_conf="2x3"
 env_args.agent_obsk=1
 ```
 
@@ -206,7 +206,7 @@ env_args.agent_obsk=1
 
 ```python
 env_args.scenario="coupled_half_cheetah"
-env_args.agent_conf="2x3
+env_args.agent_conf="1p1"
 env_args.agent_obsk=1
 ```
 

--- a/src/multiagent_mujoco/mujoco_multi.py
+++ b/src/multiagent_mujoco/mujoco_multi.py
@@ -78,9 +78,16 @@ class MujocoMulti(MultiAgentEnv):
         if self.env_version == 2:
             try:
                 self.wrapped_env = NormalizedActions(gym.make(self.scenario))
-            except gym.error.Error:
-                from envs import REGISTRY as env_REGISTRY
-                self.wrapped_env = NormalizedActions(TimeLimit(partial(env_REGISTRY[self.scenario],**kwargs["env_args"])(), max_episode_steps=self.episode_limit))
+            except gym.error.Error:  # env not in gym
+                if self.scenario in ["manyagent_ant"]:
+                    from .manyagent_ant import ManyAgentAntEnv as this_env
+                elif self.scenario in ["manyagent_swimmer"]:
+                    from .manyagent_swimmer import ManyAgentSwimmerEnv as this_env
+                elif self.scenario in ["coupled_half_cheetah"]:
+                    from .coupled_half_cheetah import CoupledHalfCheetah as this_env
+                else:
+                    raise NotImplementedError('Custom env not implemented!')
+                self.wrapped_env = NormalizedActions(TimeLimit(this_env(**kwargs["env_args"]), max_episode_steps=self.episode_limit))
         else:
             assert False,  "not implemented!"
         self.timelimit_env = self.wrapped_env.env


### PR DESCRIPTION
For now manyagent-swimmer/ant (and coupled-half-cheetah) in this repo doesn't work at all. 
No issues clearly resolves this yet.

This PR provides a minimal fix for it, which doesn't require any copying from other repos #11 .
(BTW, copying from the comix project doesn't work either because `REGISTRY` in comix's `envs` doesn't account for manyagent-swimmer/ant or coupled-half-cheetah.)

This PR also fixes relevant example `env_args` in README.