### PR TITLE
add return to render method

### DIFF
--- a/src/multiagent_mujoco/mujoco_multi.py
+++ b/src/multiagent_mujoco/mujoco_multi.py
@@ -183,7 +183,7 @@ class MujocoMulti(MultiAgentEnv):
         return self.get_obs()
 
     def render(self, **kwargs):
-        self.env.render(**kwargs)
+        return self.env.render(**kwargs)
 
     def close(self):
         raise NotImplementedError


### PR DESCRIPTION
This allows mode='rgb_array' and 'depth_array' to return the array as in the original single-agent mujoco gym env. These modes are faster than mode='human'.